### PR TITLE
Fix edge case where listener was not being unset

### DIFF
--- a/src/contra.emitter.js
+++ b/src/contra.emitter.js
@@ -55,9 +55,9 @@
         var args = atoa(arguments);
         var ctx = this || thing;
         if (type === 'error' && opts.throws !== false && !et.length) { throw args.length === 1 ? args[0] : args; }
-        evt[type] = et.filter(function emitter (listen) {
+        et.forEach(function emitter (listen) {
           if (opts.async) { debounce(listen, args, ctx); } else { listen.apply(ctx, args); }
-          return !listen._once;
+          if (listen._once) { thing.off(type, listen); }
         });
         return thing;
       };


### PR DESCRIPTION
This fixes the following code from not emitting more than once:

``` js
var emitter = require('./')

var ee = emitter()

var listener = function () {
  console.log('hello')
  ee.off('change', listener)
}

ee.on('change', listener)

ee.emit('change')
ee.emit('change')
ee.emit('change')
```

I'm aware there's a `once` method, but this use case should also work. :smile: 
